### PR TITLE
Fix OTP race condition: verify Redis write before sending email

### DIFF
--- a/app.py
+++ b/app.py
@@ -356,7 +356,7 @@ def generate_otp():
     return str(random.randint(100000, 999999))
 
 def save_otp(email, otp):
-    redis_client.setex(f"otp:{email}", 300, otp)
+    return redis_client.setex(f"otp:{email}", 300, otp)
 
 def get_otp(email):
     return redis_client.get(f"otp:{email}")
@@ -390,17 +390,22 @@ def request_edit():
 
         # 4) Generate + Send OTP
         otp = generate_otp()
-        duration=perf_counter()-start
-        print(f"{duration:.4f} seconds 367")
-        start=perf_counter()
-        save_otp(email, otp)
-        duration=perf_counter()-start
-        print(f"{duration:.4f} seconds 371")
-        start=perf_counter()
-        
-        send_email(email, otp)
-        duration=perf_counter()-start
-        print(f"{duration:.4f} seconds 376")
+
+        # Save OTP to Redis FIRST and verify it succeeded
+        result = save_otp(email, otp)
+        if not result:
+            flash("Could not generate verification code. Please try again.", "danger")
+            return redirect(url_for("request_edit"))
+
+        # Only send email if Redis write confirmed
+        try:
+            send_email(email, otp)
+        except Exception:
+            # If email fails, clean up Redis so user can retry immediately
+            delete_otp(email)
+            flash("Failed to send verification email. Please try again.", "danger")
+            return redirect(url_for("request_edit"))
+
         session["otp_email"] = email
         flash("Verification code sent to your email.", "success")
         return redirect(url_for("verify_otp"))


### PR DESCRIPTION
Fixes #14 - OTP not received by users By - SR12

**Root cause:**
'send_email()' was being called without verifying the Redis write succeeded. 
Two failure scenarios existed:

**Scenario 1 — Redis fails silently:**
The OTP is never stored in Redis, but the email is sent anyway. 
The user receives the code but it always returns "OTP expired" when entered.
This is exactly what was reported in #14.

**Scenario 2 — Email/SMTP fails:**
The OTP is stored in Redis (5 min timer starts) but the email never arrives.
The user is locked out for 5 minutes with no way to retry.

**Changes made:**
- 'save_otp()' now returns the Redis result so the caller can verify it succeeded
- `request_edit()` checks the Redis write before sending the email
- If Redis fails → user gets a clear error message and can retry immediately
- If SMTP fails → Redis key is deleted so user can retry immediately
- Removed leftover debug timing print statements from production code