### PR TITLE
#40 issue resolved

### DIFF
--- a/templates/collaborators.html
+++ b/templates/collaborators.html
@@ -204,19 +204,25 @@ Edit
 
 <!-- SOCIAL -->
 
+{% if c.linkedin.strip() or c.github.strip() %}
 <div class="flex items-center gap-3 mt-4">
 
+{% if c.linkedin %}
 <a href="{{ c.linkedin }}" target="_blank">
 <img src="https://cdn-icons-png.flaticon.com/512/174/174857.png"
 class="w-5 h-5 hover:scale-110">
 </a>
+{% endif %}
 
+{% if c.github %}
 <a href="{{ c.github }}" target="_blank">
 <img src="https://cdn-icons-png.flaticon.com/512/25/25231.png"
 class="w-5 h-5 hover:scale-110">
 </a>
+{% endif %}
 
 </div>
+{% endif %}
 
 
 </div>


### PR DESCRIPTION
 Fixes #40
Resolved an issue where LinkedIn and GitHub icons were displayed even when no valid links were provided.
 Updated Jinja template logic to render icons only when valid links exist
Previously, icons were shown even for empty fields, leading to poor user experience and non-functional links. This fix ensures a cleaner and more accurate UI.
- Verified icons appear only when valid LinkedIn/GitHub URLs are present
- Confirmed icons are hidden for empty 